### PR TITLE
feat: Add instructor authentication to instructor layout

### DIFF
--- a/app/(dashboard)/(routes)/instructor/layout.tsx
+++ b/app/(dashboard)/(routes)/instructor/layout.tsx
@@ -1,4 +1,15 @@
+import { redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs";
+
+import { isInstructor } from "@/lib/instructor";
+
 const InstructorLayout = ({ children }: { children: React.ReactNode }) => {
+	const { userId } = auth();
+
+	if (!isInstructor(userId)) {
+		return redirect("/");
+	}
+
 	return <main>{children}</main>;
 };
 


### PR DESCRIPTION
This commit adds instructor authentication to the instructor layout in the dashboard. Now, only users with an instructor role will be able to access this layout. If a user without the instructor role tries to access it, they will be redirected to the homepage.